### PR TITLE
Using the git:// protocol is deprecated

### DIFF
--- a/Dockerfile-allsims
+++ b/Dockerfile-allsims
@@ -16,7 +16,7 @@ WORKDIR /workdir
 RUN apt-get install -y libc6-dev libpcap-dev && \
     apt-get install -y $RUNPKGS  && \
     apt-get install -y $BUILDPKGS && \
-    git clone --depth 1 --single-branch git://github.com/simh/simh.git && \
+    git clone --depth 1 --single-branch https://github.com/simh/simh.git && \
     cd simh && \
     make $sims && \
     mkdir /simh-bin && cp -r BIN/* /simh-bin && \

--- a/Dockerfile-allsims-bb
+++ b/Dockerfile-allsims-bb
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install $RUNPKGS
 WORKDIR /workdir
 
 RUN apt-get update && apt-get install  $BUILDPKGS && \
-	git clone git://github.com/simh/simh.git && \
+	git clone https://github.com/simh/simh.git && \
 	cd simh && \
 	sed -e "s/\$(error Retry your build without specifying USE_NETWORK=1)/# SUPRESSED /g" makefile > makefile2 && \
 	make LIBPATH=/usr/lib INCPATH=/usr/include USE_NETWORK=1 -f makefile2 && \


### PR DESCRIPTION
Using the git:// protocol is ill supported and gives the following error on debian:

`github.com[0: 140.82.121.4]: errno=Connection timed out`

Switching to https solves this problem.