### PR TITLE
The 'vax' emulator complains about missing libedit

### DIFF
--- a/Dockerfile-allsims
+++ b/Dockerfile-allsims
@@ -7,7 +7,7 @@ LABEL description="Selected SIMH simulators"
 LABEL maintainer="Jordi Guillaumes Pons <jguillaumes@gmail.com>"
 
 ENV BUILDPKGS "gcc git libvdeplug-dev libbluetooth-dev make"
-ENV RUNPKGS "net-tools vde2 libvdeplug2 nano"
+ENV RUNPKGS "net-tools vde2 libvdeplug2 nano libedit2"
 
 RUN apt-get update
 

--- a/Dockerfile-allsims-bb
+++ b/Dockerfile-allsims-bb
@@ -3,7 +3,7 @@ FROM busybox:glibc
 MAINTAINER Jordi Guillaumes Pons <jg@jordi.guillaumes.name>
 
 ENV BUILDPKGS "git gcc libc-dev make vde2-dev libpcap-dev linux-headers readline-dev"
-ENV RUNPKGS "net-tools vde2 vde2-libs libpcap nano readline bash"
+ENV RUNPKGS "net-tools vde2 vde2-libs libpcap nano readline bash libedit2"
 
 RUN apt-get update && apt-get install $RUNPKGS 
 


### PR DESCRIPTION
Adding libedit2 to the `RUNPKGS` envvar fixes this.